### PR TITLE
Add transient services

### DIFF
--- a/container.go
+++ b/container.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Container interface {
-	Put(key string, service *Service)
-	Get(key string) (*Service, bool)
+	Put(key string, service Service)
+	Get(key string) (Service, bool)
 }
 
 type containerImpl struct {
@@ -17,15 +17,15 @@ func NewContainer() Container {
 	return &containerImpl{}
 }
 
-func (c *containerImpl) Put(key string, service *Service) {
+func (c *containerImpl) Put(key string, service Service) {
 	c.m.Store(key, service)
 }
 
-func (c *containerImpl) Get(key string) (s *Service, ok bool) {
+func (c *containerImpl) Get(key string) (s Service, ok bool) {
 	v, ok := c.m.Load(key)
 	if !ok {
 		return
 	}
-	s, ok = v.(*Service)
+	s, ok = v.(Service)
 	return
 }

--- a/di.go
+++ b/di.go
@@ -26,6 +26,34 @@ func MustRegister[TSvc, TImpl any](c Container) {
 	must(Register[TSvc, TImpl](c))
 }
 
+// RegisterTransient adds a transient service of the type TSvc
+// with an implementation of the type TImpl to the provided container.
+func RegisterTransient[TSvc, TImpl any](c Container) (err error) {
+	tImpl := getType[TImpl]()
+	tIf := getType[TSvc]()
+	if tIf.Kind() != reflect.Interface {
+		err = ErrNoInterface
+		return
+	}
+	if !tImpl.Implements(tIf) && !reflect.PointerTo(tImpl).Implements(tIf) {
+		err = ErrDoesNotImplInterface
+		return
+	}
+	key := getInterfaceKey(tIf)
+	c.Put(key, &transientService{
+		implType: tImpl,
+	})
+	return
+}
+
+// MustRegisterTransient adds a transient service of the type TSvc
+// with an implementation of the type TImpl to the provided container.
+//
+// It panics when a registration is not possible.
+func MustRegisterTransient[TSvc, TImpl any](c Container) {
+	must(RegisterTransient[TSvc, TImpl](c))
+}
+
 func Get[T any](c Container) (s T, err error) {
 	tIf := getType[T]()
 	if tIf.Kind() != reflect.Interface {

--- a/di.go
+++ b/di.go
@@ -16,7 +16,7 @@ func Register[TSvc, TImpl any](c Container) (err error) {
 		return
 	}
 	key := getInterfaceKey(tIf)
-	c.Put(key, &Service{
+	c.Put(key, &singletonService{
 		ImplType: tImpl,
 	})
 	return

--- a/di_test.go
+++ b/di_test.go
@@ -13,7 +13,7 @@ type testImpl struct {
 	A a
 }
 
-func TestRegister(t *testing.T) {
+func TestRegisterSingleton(t *testing.T) {
 	c := NewContainer()
 
 	// Infers testImpl as type instead
@@ -30,7 +30,7 @@ func TestRegister(t *testing.T) {
 	v, ok := c.(*containerImpl).m.Load(key)
 	assert.True(t, ok, "no service has been registered")
 
-	svc := v.(*Service)
+	svc := v.(*singletonService)
 	assert.Equal(t, svc.ImplType, reflect.TypeOf(testImpl{}))
 	assert.False(t, svc.IsBuilt)
 	assert.Equal(t, svc.Instance, reflect.Value{})

--- a/service.go
+++ b/service.go
@@ -26,6 +26,25 @@ func (s *singletonService) Build(c Container) (instance reflect.Value) {
 	instance = reflect.New(s.ImplType)
 	s.Instance = instance
 	s.IsBuilt = true
+	injectFields(instance, c)
+	return
+}
+
+// transientService describes a dependency that should get created anew
+// each time it is requested from the container.
+type transientService struct {
+	implType reflect.Type
+}
+
+func (s *transientService) Build(c Container) (instance reflect.Value) {
+	instance = reflect.New(s.implType)
+	injectFields(instance, c)
+	return
+}
+
+// injectFields attempts to inject dependencies into a given value,
+// using a provided DI container.
+func injectFields(instance reflect.Value, c Container) {
 	elem := instance.Elem()
 	for i := 0; i < elem.NumField(); i++ {
 		tF := elem.Field(i)
@@ -42,5 +61,4 @@ func (s *singletonService) Build(c Container) (instance reflect.Value) {
 			tF.Set(fInstance)
 		}
 	}
-	return
 }

--- a/service.go
+++ b/service.go
@@ -4,13 +4,21 @@ import (
 	"reflect"
 )
 
-type Service struct {
+// Service describes what type of object should get constructed
+// and how should it get returned.
+type Service interface {
+	Build(c Container) (instance reflect.Value)
+}
+
+// singletonService describes a dependency that should only be constructed once
+// and reused for the lifetime of the application.
+type singletonService struct {
 	ImplType reflect.Type
 	IsBuilt  bool
 	Instance reflect.Value
 }
 
-func (s *Service) Build(c Container) (instance reflect.Value) {
+func (s *singletonService) Build(c Container) (instance reflect.Value) {
 	if s.IsBuilt {
 		instance = s.Instance
 		return

--- a/service_test.go
+++ b/service_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuild(t *testing.T) {
+func TestBuildSingleton(t *testing.T) {
 	c := NewContainer()
 	Register[a, struct{}](c)
 
-	s := &Service{
+	s := &singletonService{
 		ImplType: reflect.TypeOf(testImpl{}),
 		IsBuilt:  false,
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -25,4 +25,29 @@ func TestBuildSingleton(t *testing.T) {
 
 	assert.Equal(t, tInstance, s.Instance)
 	assert.True(t, s.IsBuilt)
+
+	tInstance2 := s.Build(c)
+	assert.Equal(t, tInstance, tInstance2)
+	assert.Same(t, tInstance.Interface(), tInstance2.Interface())
+}
+
+func TestBuildTransient(t *testing.T) {
+	c := NewContainer()
+	Register[a, struct{}](c)
+
+	s := &transientService{
+		implType: reflect.TypeOf(testImpl{}),
+	}
+
+	tInstance := s.Build(c)
+	assert.NotNil(t, tInstance)
+	assert.IsType(t, &testImpl{}, tInstance.Interface())
+
+	impl := tInstance.Interface().(*testImpl)
+	assert.NotNil(t, impl.A)
+
+	tInstance2 := s.Build(c)
+	assert.IsType(t, &testImpl{}, tInstance2.Interface())
+	assert.NotEqual(t, tInstance, tInstance2)
+	assert.NotSame(t, tInstance.Interface(), tInstance2.Interface())
 }


### PR DESCRIPTION
As seen in Readme, those are created each time they are requested from the container.

I have written isolated tests for them, which prove they should work just fine. However, unlike the previous ```Service```s (renamed here ```SingletonService```s for brevity), a cyclic dependency of transient services will cause a stack overflow. I do not check the chain for loops here, as I have assumed it is out of scope for this PR.